### PR TITLE
Fixes invalid multibyte char (US-ASCII) (SyntaxError)

### DIFF
--- a/lib/stackfu.rb
+++ b/lib/stackfu.rb
@@ -1,3 +1,4 @@
+#### Ruby 1.9 needs the encoding magic field in order to work.
 # encoding: utf-8
 require 'rubygems'
 

--- a/lib/stackfu.rb
+++ b/lib/stackfu.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 require 'rubygems'
 
 $:.unshift(File.dirname(__FILE__)) unless


### PR DESCRIPTION
When running StackFu gem under Ruby 1.9.x. StackFu presents the error invalid multibyte char (US-ASCII) (SyntaxError). In order to fix this for Ruby 1.9.x users # encoding: utf-8 needs to be defined in lib/stackfu.rb.
